### PR TITLE
Add notes to README about the correct repo to use for starter class/kit

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ engineering
 
 The `/resource` directory contains the styles and javascript along with an example image to be used during the lesson.
 
-You'll notice that this project has already been finished.  That is to say, styles have been added to the resources directory
-and except for the HTML page not including those css files, the styling has been finished.
+#### Note for starter classes:
+If you download this project and look at the index.html file, you may notice that this excercise has already been finished.  That is to say, styles have been added to the resources directory
+and except for the HTML page including commented css files, the styling has been finished.
 
 If you are grabbing these files as a starter kit for an HTML/CSS cource, we recommend using a the version available [here](https://github.com/eanakashima/front-end-lesson/).

--- a/README.md
+++ b/README.md
@@ -9,3 +9,8 @@ engineering
 * JavaScript
 
 The `/resource` directory contains the styles and javascript along with an example image to be used during the lesson.
+
+You'll notice that this project has already been finished.  That is to say, styles have been added to the resources directory
+and except for the HTML page not including those css files, the styling has been finished.
+
+If you are grabbing these files as a starter kit for an HTML/CSS cource, we recommend using a the version available [here](https://github.com/eanakashima/front-end-lesson/).


### PR DESCRIPTION
I updated the README to point folks to the https://github.com/eanakashima/front-end-lesson/ repository to get their starter kit.

we used this starter kit this past Saturday only to discover that the stylesheets were all finished so as soon as the students uncommented the inclusion from the html file, the exercise was done.
